### PR TITLE
Fix(functions): Correct userID format and improve passkey stability

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -195,7 +195,7 @@ exports.regOptions = functions
     const options = generateRegistrationOptions({
       rpName,
       rpID,
-      userID: Buffer.from(decoded.uid, 'utf8'),
+      userID: decoded.uid,
       userName: decoded.email || decoded.uid,
       attestationType: 'none',
       excludeCredentials,


### PR DESCRIPTION
This commit provides a comprehensive fix for the passkey feature, addressing the root cause of the "Failed to generate registration challenge" error and including previous stability improvements.

The following changes have been made:

1.  **Corrected `userID` Format (`regOptions`):**
    - The `userID` passed to `generateRegistrationOptions` has been changed from a Buffer to a plain string (`decoded.uid`). This corrects a data type mismatch that was the root cause of the challenge generation failure.

2.  **Hardened Registration Flow (`regOptions`):**
    - The function now gracefully handles corrupted or malformed credential IDs stored in Firestore by skipping them instead of crashing.
    - Added a validation check to ensure a challenge is successfully generated before attempting to write it to Firestore.

3.  **Corrected Authentication Logic (`authVerify`):**
    - The function now correctly uses `credential.id` to look up credentials.
    - The verification process now uses the trusted credential ID from the server-side document.

4.  **Added Input Validation (`authVerify`):**
    - A validation check ensures `credential.id` is a non-empty string before use.

These cumulative changes make the passkey feature significantly more resilient, secure, and reliable.